### PR TITLE
(#14465) Add inetd option for tftpd.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,13 +15,17 @@ Parameters:
 * address: bind address, default 0.0.0.0.
 * port: bind port, default 69.
 * options: service option, default --secure.
+* inetd: run service via inetd, default false. (Warning: this option when enabled to true is not compatible with custom service options).
+* inetd_conf: inetd.conf file path, default /etc/inetd.conf.
+
+Enabling inetd requires [puppetlabs-inetd](https://github.com/puppetlabs/puppetlabs-inetd) module.
 
 Example:
 
     class tftp {
       directory => '/opt/tftp',
       address   => $::ipaddress,
-      options   => '--secure --ipv6 --timeout 60',
+      options   => '--ipv6 --timeout 60',
     }
 
 ### tftp::file

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -2,18 +2,36 @@
 #
 # Parameters:
 #
+#   [*username*]: tftp service username.
+#   [*directory*]: tftp service file directory.
+#   [*address*]: tftp service bind address (default 0.0.0.0).
+#   [*port*]: tftp service bind port (default 69).
+#   [*options*]: tftp service bind port (default 69).
+#   [*inetd*]: tftp service bind port (default 69).
+#   [*inetd_conf*]: tftp service bind port (default 69).
+#
 # Actions:
 #
 # Requires:
 #
+#   puppetlabs-inetd when inetd = true.
+#
 # Usage:
 #
+#   class tftp {
+#     directory => '/opt/tftp',
+#     address   => $::ipaddress,
+#     options   => '--ipv6 --timeout 60',
+#   }
+#
 class tftp (
-  $username  = $tftp::params::username,
-  $directory = $tftp::params::directory,
-  $address   = $tftp::params::address,
-  $port      = $tftp::params::port,
-  $options   = $tftp::params::options
+  $username   = $tftp::params::username,
+  $directory  = $tftp::params::directory,
+  $address    = $tftp::params::address,
+  $port       = $tftp::params::port,
+  $options    = $tftp::params::options,
+  $inetd      = false,
+  $inetd_conf = $tftp::params::inetd_conf
 ) inherits tftp::params {
   package { 'tftpd-hpa':
     ensure => present,
@@ -28,8 +46,40 @@ class tftp (
     require => Package['tftpd-hpa'],
   }
 
+  if $inetd {
+    if $options != '--secure' {
+      fail('tftp class does not support custom options when inetd is enabled.')
+    }
+
+    include 'inetd'
+
+    augeas { 'inetd_tftp':
+      changes => [
+        "ins tftp after /files${inetd_conf}",
+        "set /files${inetd_conf}/tftp/socket dgram",
+        "set /files${inetd_conf}/tftp/protocol udp",
+        "set /files${inetd_conf}/tftp/wait wait",
+        "set /files${inetd_conf}/tftp/user ${username}",
+        "set /files${inetd_conf}/tftp/command /usr/libexec/tftpd",
+        "set /files${inetd_conf}/tftp/arguments/1 tftpd",
+        "set /files${inetd_conf}/tftp/arguments/2 --address",
+        "set /files${inetd_conf}/tftp/arguments/3 ${address}:${port}",
+        "set /files${inetd_conf}/tftp/arguments/4 --secure",
+        "set /files${inetd_conf}/tftp/arguments/5 ${directory}",
+      ],
+      require => Class['inetd'],
+    }
+
+    $svc_ensure = stopped
+    $svc_enable = false
+  } else {
+    $svc_ensure = running
+    $svc_enable = true
+  }
+
   service { 'tftpd-hpa':
-    ensure    => running,
+    ensure    => $svc_ensure,
+    enable    => $svc_enable,
     provider  => $tftp::params::provider,
     hasstatus => $tftp::params::hasstatus,
     pattern   => '/usr/sbin/in.tftpd',

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -9,10 +9,11 @@
 # Usage:
 #
 class tftp::params {
-  $address  = '0.0.0.0'
-  $port     = '69'
-  $username = 'tftp'
-  $options  = '--secure'
+  $address    = '0.0.0.0'
+  $port       = '69'
+  $username   = 'tftp'
+  $options    = '--secure'
+  $inetd_conf = '/etc/inetd.conf'
 
   case $::operatingsystem {
     'debian': {

--- a/spec/classes/tftp_spec.rb
+++ b/spec/classes/tftp_spec.rb
@@ -8,21 +8,64 @@ describe 'tftp', :type => :class do
     it { should contain_file('/etc/default/tftpd-hpa') }
     it { should contain_package('tftpd-hpa') }
     it { should contain_service('tftpd-hpa').with({
+      'ensure'    => 'running',
+      'enable'    => true,
       'hasstatus' => false,
       'provider'  => nil,
     }) }
   end
 
   describe 'when deploying on ubuntu' do
-    let(:facts) { { :operatingsystem => 'ubuntu',
+    let(:facts) { { :operatingsystem => 'Ubuntu',
                     :path            => '/usr/local/bin:/usr/bin:/bin', } }
 
     it { should contain_package('tftpd-hpa') }
     it { should contain_file('/etc/default/tftpd-hpa') }
     it { should contain_service('tftpd-hpa').with({
+      'ensure'    => 'running',
+      'enable'    => true,
       'hasstatus' => true,
       'provider'  => 'upstart',
     }) }
   end
 
+  describe 'when deploying with inetd' do
+    let(:facts) { { :operatingsystem => 'Debian',
+                    :path            => '/usr/local/bin:/usr/bin:/bin', } }
+    let(:params) { { :inetd => true, } }
+
+    it { should contain_package('tftpd-hpa') }
+    it { should contain_file('/etc/default/tftpd-hpa') }
+    it { should contain_class('inetd') }
+    it { should contain_augeas('inetd_tftp').with({
+      'changes' => [
+        "ins tftp after /files/etc/inetd.conf",
+        "set /files/etc/inetd.conf/tftp/socket dgram",
+        "set /files/etc/inetd.conf/tftp/protocol udp",
+        "set /files/etc/inetd.conf/tftp/wait wait",
+        "set /files/etc/inetd.conf/tftp/user tftp",
+        "set /files/etc/inetd.conf/tftp/command /usr/libexec/tftpd",
+        "set /files/etc/inetd.conf/tftp/arguments/1 tftpd",
+        "set /files/etc/inetd.conf/tftp/arguments/2 --address",
+        "set /files/etc/inetd.conf/tftp/arguments/3 0.0.0.0:69",
+        "set /files/etc/inetd.conf/tftp/arguments/4 --secure",
+        "set /files/etc/inetd.conf/tftp/arguments/5 /srv/tftp",
+      ],
+    }) }
+    it { should contain_service('tftpd-hpa').with({
+      'ensure'    => 'stopped',
+      'enable'    => false,
+      'hasstatus' => false,
+      'provider'  => nil,
+    }) }
+  end
+
+  describe 'when deploying with inetd and custom options' do
+    let(:facts) { { :operatingsystem => 'Debian',
+                    :path            => '/usr/local/bin:/usr/bin:/bin', } }
+    let(:params) { { :inetd          => true,
+                     :options        => '--timeout 5 --secure', } }
+
+   it { expect { should contain_class('tftp') }.to raise_error(Puppet::Error) }
+  end
 end


### PR DESCRIPTION
This adds the ability to use inetd for tftpd service. This merges the
functionality provided in the puppet-tftp module to puppetlabs-tftp.
