### PR TITLE
Fix the message "cannot set groups for user nobody"

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -58,9 +58,10 @@ class tftp (
     xinetd::service { 'tftp':
       port        => $port,
       protocol    => 'udp',
-      server_args => "${options} ${directory}",
+      server_args => "${options} -u ${username} ${directory}",
       server      => $binary,
-      user        => $username,
+      user        => 'root',
+      group       => 'root',
       bind        => $address,
       socket_type => 'dgram',
       cps         => '100 2',


### PR DESCRIPTION
Hi,

tftpd-hpa try to change the uid and gid of the process before serving a file
and it can't if xinetd start the process with a user other than root.

This result is this following message and tftp can't serve file
 in.tftpd[17609]: cannot set groups for user nobody

To customise user/group of the running process we need to use -u option

note: I use tftp-hpa 5.2-4 on debian

Best regards
