### PR TITLE
Require the package on the tftp xinetd service.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -66,6 +66,7 @@ class tftp (
       flags       => 'IPv4',
       per_source  => '11',
       wait        => 'yes',
+      require     => Package[$package],
     }
 
     $svc_ensure = stopped


### PR DESCRIPTION
The xinetd::service type drops an xinetd config. That config is invalid
before the tftp package is installed and during that window xinetd may
be started. xinetd will start with tftp ignored, and will need to be
manually restarted to enable tftp. This change eliminates that window.
