### PR TITLE
Add the pidfile flag in the default options.

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -4,7 +4,7 @@
 class tftp::params {
   $address    = '0.0.0.0'
   $port       = '69'
-  $options    = '--secure'
+  $options    = '--secure --pidfile=$PIDFILE'
   $binary     = '/usr/sbin/in.tftpd'
   $inetd      = true
 


### PR DESCRIPTION
Otherwise the in.tftpd process won't drop a pidfile.
