### PR TITLE
fixing issues with missing @ for variables in template

### DIFF
--- a/templates/tftpd-hpa.erb
+++ b/templates/tftpd-hpa.erb
@@ -1,6 +1,6 @@
 # /etc/default/tftpd-hpa
 
-TFTP_USERNAME="<%= username %>"
-TFTP_DIRECTORY="<%= directory %>"
-TFTP_ADDRESS="<%= address %>:<%= port %>"
-TFTP_OPTIONS="<%= options %>"
+TFTP_USERNAME="<%= @username %>"
+TFTP_DIRECTORY="<%= @directory %>"
+TFTP_ADDRESS="<%= @address %>:<%= @port %>"
+TFTP_OPTIONS="<%= @options %>"


### PR DESCRIPTION
Quick update to the template to fix errors caused by a missing @ sign in front of the variables used.
