### PR TITLE
Added files parameter to define resources quickly

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Parameters:
 * port: bind port, default 69.
 * options: service option, default --secure.
 * inetd: run service via xinetd, default true.
+* files: hash of tftp::file resources to create, default undef.
 
 Example:
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -8,6 +8,7 @@
 #   [*port*]: tftp service bind port (default 69).
 #   [*options*]: tftp service bind port (default 69).
 #   [*inetd*]: Run as an xinetd service instead of standalone daemon (false)
+#   [*files*]: hash of tftp::file resources to create (undef)
 #
 # Actions:
 #
@@ -33,6 +34,7 @@ class tftp (
   $package    = $tftp::params::package,
   $binary     = $tftp::params::binary,
   $defaults   = $tftp::params::defaults,
+  $files      = $tftp::params::files,
 ) inherits tftp::params {
   $virtual_package = 'tftpd-hpa'
 
@@ -89,5 +91,9 @@ class tftp (
     hasstatus => $tftp::params::hasstatus,
     pattern   => '/usr/sbin/in.tftpd',
     start     => $start,
+  }
+
+  if $files {
+    create_resources('tftp::file', $files)
   }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -7,6 +7,7 @@ class tftp::params {
   $options    = '--secure'
   $binary     = '/usr/sbin/in.tftpd'
   $inetd      = true
+  $files      = undef
 
   case $::osfamily {
     'debian': {

--- a/spec/classes/tftp_spec.rb
+++ b/spec/classes/tftp_spec.rb
@@ -194,4 +194,17 @@ describe 'tftp', :type => :class do
     }
   end
 
+  describe 'when deploying a file from init.pp (on redhat)' do
+    let(:facts) { { :operatingsystem => 'RedHat',
+                    :osfamily        => 'redhat',
+                    :path            => '/usr/local/bin:/usr/bin:/bin', } }
+    let (:params) { { 'files' => { 'sample' => { 'content' => 'hi' }} } }
+
+    it {
+      should contain_file('/var/lib/tftpboot/sample').with({
+        'content' => 'hi',
+      })
+    }
+  end
+
 end


### PR DESCRIPTION
This patch allows for the creation of tftp::resources via a class parameter - possibly from hiera or an ENC.
