### PR TITLE
Fixed systemd issue on Ubuntu 15.04 and later versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,5 +88,5 @@ The examples use a module acme and the tftp files should be placed in calling mo
 The module have been tested on the following operating systems. Testing and patches for other platforms are welcomed.
 
 * Debian Wheezy
-* Ubuntu Oneiric
+* Ubuntu 12.04, 14.04, 16.04
 * CentOS

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -22,7 +22,6 @@ class tftp::params {
         'ubuntu': {
           # ubuntu now uses systemd
           if versioncmp($::operatingsystemrelease, '15.04') >= 0 {
-            $is_systemd = true
             $provider = 'systemd'
           } else {
             $provider   = 'upstart'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -20,9 +20,15 @@ class tftp::params {
           $provider   = undef
         }
         'ubuntu': {
+          # ubuntu now uses systemd
+          if versioncmp($::operatingsystemrelease, '15.04') >= 0 {
+            $is_systemd = true
+            $provider = 'systemd'
+          } else {
+            $provider   = 'upstart'
+          }
           $directory  = '/var/lib/tftpboot'
           $hasstatus  = true
-          $provider   = 'upstart'
         }
         default: {
           fail "${::operatingsystem} is not supported"

--- a/metadata.json
+++ b/metadata.json
@@ -31,7 +31,9 @@
     {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
-        "11.10"
+        "12.04",
+        "14.04",
+        "16.04"
       ]
     }
   ],

--- a/spec/classes/tftp_spec.rb
+++ b/spec/classes/tftp_spec.rb
@@ -18,10 +18,11 @@ describe 'tftp', :type => :class do
     }
   end
 
-  describe 'when deploying on ubuntu as standalone' do
-    let(:facts) { { :operatingsystem  => 'Ubuntu',
-                    :osfamily         => 'Debian',
-                    :path             => '/usr/local/bin:/usr/bin:/bin', } }
+  describe 'when deploying on ubuntu 14.04 as standalone' do
+    let(:facts) { { :operatingsystem        => 'Ubuntu',
+                    :osfamily               => 'Debian',
+                    :operatingsystemrelease => '14.04',
+                    :path                   => '/usr/local/bin:/usr/bin:/bin', } }
     let(:params) { {  :inetd  => false, } }
     it {
       should contain_package('tftpd-hpa')
@@ -31,6 +32,60 @@ describe 'tftp', :type => :class do
         'enable'    => true,
         'hasstatus' => true,
         'provider'  => 'upstart',
+      })
+    }
+  end
+
+  describe 'when deploying on ubuntu 14.10 as standalone' do
+    let(:facts) { { :operatingsystem        => 'Ubuntu',
+                    :osfamily               => 'Debian',
+                    :operatingsystemrelease => '14.10',
+                    :path                   => '/usr/local/bin:/usr/bin:/bin', } }
+    let(:params) { {  :inetd  => false, } }
+    it {
+      should contain_package('tftpd-hpa')
+      should contain_file('/etc/default/tftpd-hpa')
+      should contain_service('tftpd-hpa').with({
+        'ensure'    => 'running',
+        'enable'    => true,
+        'hasstatus' => true,
+        'provider'  => 'upstart',
+      })
+    }
+  end
+
+  describe 'when deploying on ubuntu 15.04 or greater as standalone' do
+    let(:facts) { { :operatingsystem        => 'Ubuntu',
+                    :osfamily               => 'Debian',
+                    :operatingsystemrelease => '15.04',
+                    :path                   => '/usr/local/bin:/usr/bin:/bin', } }
+    let(:params) { {  :inetd  => false, } }
+    it {
+      should contain_package('tftpd-hpa')
+      should contain_file('/etc/default/tftpd-hpa')
+      should contain_service('tftpd-hpa').with({
+        'ensure'    => 'running',
+        'enable'    => true,
+        'hasstatus' => true,
+        'provider'  => 'systemd',
+      })
+    }
+  end
+
+  describe 'when deploying on ubuntu 16.04 or greater as standalone' do
+    let(:facts) { { :operatingsystem        => 'Ubuntu',
+                    :osfamily               => 'Debian',
+                    :operatingsystemrelease => '16.04',
+                    :path                   => '/usr/local/bin:/usr/bin:/bin', } }
+    let(:params) { {  :inetd  => false, } }
+    it {
+      should contain_package('tftpd-hpa')
+      should contain_file('/etc/default/tftpd-hpa')
+      should contain_service('tftpd-hpa').with({
+        'ensure'    => 'running',
+        'enable'    => true,
+        'hasstatus' => true,
+        'provider'  => 'systemd',
       })
     }
   end

--- a/spec/classes/tftp_spec.rb
+++ b/spec/classes/tftp_spec.rb
@@ -157,10 +157,11 @@ describe 'tftp', :type => :class do
     }
   end
 
-  describe 'when deploying with xinetd on ubuntu' do
-    let (:facts) { {  :osfamily         => 'Debian',
-                      :operatingsystem  => 'Ubuntu',
-                      :path     => '/usr/local/bin:/usr/bin:/bin', } }
+  describe 'when deploying with xinetd on ubuntu 14.04' do
+    let (:facts) { {  :osfamily               => 'Debian',
+                      :operatingsystem        => 'Ubuntu',
+                      :operatingsystemrelease => '14.04',
+                      :path                   => '/usr/local/bin:/usr/bin:/bin', } }
     it {
       should contain_class('xinetd')
       should contain_service('tftpd-hpa').with({

--- a/spec/defines/tftp_file_spec.rb
+++ b/spec/defines/tftp_file_spec.rb
@@ -21,10 +21,11 @@ describe 'tftp::file' do
     }
   end
 
-  describe 'when deploying on ubuntu' do
-    let(:facts) { { :operatingsystem => 'ubuntu',
-                    :osfamily        => 'Debian',
-                    :path            => '/usr/local/bin:/usr/bin:/bin', } }
+  describe 'when deploying on ubuntu 14.04' do
+    let(:facts) { { :operatingsystem        => 'ubuntu',
+                    :osfamily               => 'Debian',
+                    :operatingsystemrelease => '14.04',
+                    :path                   => '/usr/local/bin:/usr/bin:/bin', } }
 
     it {
       should contain_class('tftp')


### PR DESCRIPTION
Upstart is no longer used in Ubuntu since 15.04.  This pull request checks if the version is equal to or later than 15.04 systemd is used otherwise upstart is used.