### PR TITLE
Support for AIO in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Example:
       source => 'puppet:///modules/acme/pxelinux.0',
     }
 
-The examples use a module acme and the tftp files should be placed in calling module path i.e. (/etc/puppet/modules/acme/files).
+The examples use a module acme and the tftp files should be placed relative to the `files` directory of the calling module, i.e. ($modulepath/acme/files/).
 
 ## Supported Platforms
 


### PR DESCRIPTION
Use a variable for modulepath instead of hard coding it to a value that is no longer the default.