### PR TITLE
add additional puppet-lint checks and fix errors

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -49,6 +49,8 @@ group :development do
   gem "json_pure", '<= 2.0.1',                            :require => false if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new('2.0.0')
   gem "fast_gettext", '1.1.0',                            :require => false if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new('2.1.0')
   gem "fast_gettext",                                     :require => false if Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.1.0')
+  gem 'puppet-lint-absolute_classname-check'
+  gem 'puppet-lint-trailing_comma-check'
 end
 
 group :system_tests do

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Parameters:
 Example:
 
 ```puppet
-class tftp {
+class '::tftp': {
   directory => '/opt/tftp',
   address   => $::ipaddress,
   options   => '--ipv6 --timeout 60',
@@ -79,7 +79,7 @@ file { '/opt/tftp':
   ensure => directory,
 }
 
-class { 'tftp':
+class { '::tftp':
   directory => '/opt/tftp',
   address   => $::ipaddress,
 }

--- a/examples/init.pp
+++ b/examples/init.pp
@@ -1,3 +1,3 @@
-class { 'tftp':
+class { '::tftp':
   address => $::ipaddress,
 }

--- a/manifests/file.pp
+++ b/manifests/file.pp
@@ -39,8 +39,8 @@ define tftp::file (
   $content      = undef,
   $source       = undef
 ) {
-  include 'tftp'
-  include 'tftp::params'
+  include '::tftp'
+  include '::tftp::params'
 
   if $owner {
     $tftp_owner = $owner

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -54,7 +54,7 @@ class tftp (
   }
 
   if $inetd {
-    include 'xinetd'
+    include '::xinetd'
 
     xinetd::service { 'tftp':
       port        => $port,


### PR DESCRIPTION
We're using some additional puppet-lint checks (absolute_classname and trailing_comma) in our environment that were failing. This MR adds those checks, and fixes the errors.