### PR TITLE
Fix relative_classname_inclusion Lint warnings

### DIFF
--- a/examples/init.pp
+++ b/examples/init.pp
@@ -1,3 +1,3 @@
-class { 'tftp':
+class { '::tftp':
   address => $::ipaddress,
 }

--- a/manifests/file.pp
+++ b/manifests/file.pp
@@ -39,8 +39,8 @@ define tftp::file (
   $content      = undef,
   $source       = undef
 ) {
-  include 'tftp'
-  include 'tftp::params'
+  include ::tftp
+  include ::tftp::params
 
   if $owner {
     $tftp_owner = $owner

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -54,7 +54,7 @@ class tftp (
   }
 
   if $inetd {
-    include 'xinetd'
+    include ::xinetd
 
     xinetd::service { 'tftp':
       port        => $port,


### PR DESCRIPTION
This patchset fixes these warnings:

```
examples/init.pp:1:relative_classname_inclusion:WARNING:class included by relative name
manifests/file.pp:42:relative_classname_inclusion:WARNING:class included by relative name
manifests/file.pp:43:relative_classname_inclusion:WARNING:class included by relative name
manifests/init.pp:57:relative_classname_inclusion:WARNING:class included by relative name
```